### PR TITLE
Expose query param update helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ const path = useLocationPath()
 ```jsx
 import currentLocationPath from "on-location-changed/build/current-location-path"
 import currentQueryParams from "on-location-changed/build/current-query-params"
+import useCurrentQueryParams from "on-location-changed/build/use-current-query-params"
 ```
 
 ```jsx
 const path = currentLocationPath()
 const params = currentQueryParams()
+const readCurrentQueryParams = useCurrentQueryParams()
 ```
 
 ```jsx
@@ -78,4 +80,16 @@ const subscription = onSelectedQueryParamsChanged("project_ids", (params) => {
 })
 
 subscription.disconnect()
+```
+
+```jsx
+import {locationPathWithQueryParams, pushQueryParamUpdates} from "on-location-changed/build/query-param-updates"
+```
+
+```jsx
+const path = locationPathWithQueryParams("/timelogs", {project_ids: ["1", "2"]})
+
+pushQueryParamUpdates(router, readCurrentQueryParams(), "/timelogs", {
+  project_ids: ["3"]
+})
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -4,12 +4,22 @@ import onSelectedQueryParamsChanged from "./on-selected-query-params-changed.js"
 import onLocationChanged from "./on-location-changed.js"
 import useLocationPath from "./use-location-path.js"
 import useSelectedQueryParams from "./use-selected-query-params.js"
+import useCurrentQueryParams from "./use-current-query-params.js"
+import {
+  locationPathWithQueryParams,
+  pathForQueryParamUpdates,
+  pushQueryParamUpdates
+} from "./query-param-updates.js"
 
 export {
   currentLocationPath,
   currentQueryParams,
+  locationPathWithQueryParams,
   onLocationChanged,
   onSelectedQueryParamsChanged,
+  pathForQueryParamUpdates,
+  pushQueryParamUpdates,
+  useCurrentQueryParams,
   useLocationPath,
   useSelectedQueryParams
 }

--- a/src/query-param-updates.js
+++ b/src/query-param-updates.js
@@ -1,0 +1,137 @@
+// @ts-check
+
+/**
+ * @typedef {string | number | boolean | null | undefined} QueryParamScalar
+ * @typedef {QueryParamScalar | QueryParamScalar[]} QueryParamValue
+ * @typedef {Record<string, QueryParamValue | string | string[] | undefined>} QueryParams
+ * @typedef {Record<string, QueryParamValue>} QueryParamUpdates
+ * @typedef {{excludeKeys?: string[]}} QueryParamUpdateOptions
+ * @typedef {{push: (path: string) => unknown}} QueryParamRouter
+ */
+
+/**
+ * Builds a location path with serialized query params.
+ * @param {string} path Pathname that should receive the query string.
+ * @param {QueryParams} [queryParams] Query params to serialize.
+ * @returns {string} Path with query params appended.
+ */
+export function locationPathWithQueryParams(path, queryParams = {}) {
+  const url = new URL(path, "http://placeholder")
+
+  for (const key of Object.keys(queryParams).sort()) {
+    appendQueryParam(url.searchParams, key, queryParams[key])
+  }
+
+  const search = url.searchParams.toString()
+
+  return `${url.pathname}${search ? `?${search}` : ""}${url.hash}`
+}
+
+/**
+ * Pushes a same-route path after applying query parameter updates.
+ * @param {QueryParamRouter} router Router with push navigation.
+ * @param {QueryParams} currentParams Current query params.
+ * @param {string} path Pathname that should receive the updated query string.
+ * @param {QueryParamUpdates} updates Query entries that replace same-named current values.
+ * @param {QueryParamUpdateOptions} [options] Keys to omit from the serialized query.
+ * @returns {void} Nothing.
+ */
+export function pushQueryParamUpdates(
+  router,
+  currentParams,
+  path,
+  updates,
+  options = {}
+) {
+  const nextPath = pathForQueryParamUpdates(currentParams, path, updates, options)
+  if (nextPath) router.push(nextPath)
+}
+
+/**
+ * Builds a same-route path after applying query parameter updates.
+ * @param {QueryParams} currentParams Current query params.
+ * @param {string} path Pathname that should receive the updated query string.
+ * @param {QueryParamUpdates} updates Query entries that replace same-named current values.
+ * @param {QueryParamUpdateOptions} [options] Keys to omit from the serialized query.
+ * @returns {string | null} The route path, or null when no params changed.
+ */
+export function pathForQueryParamUpdates(
+  currentParams,
+  path,
+  updates,
+  options = {}
+) {
+  const excludedKeys = new Set(options.excludeKeys || [])
+  const updateKeys = new Set(Object.keys(updates))
+  const currentSearchParams = searchParamsFor(currentParams, excludedKeys)
+  const nextSearchParams = new URLSearchParams()
+
+  appendCurrentParams(nextSearchParams, currentParams, excludedKeys, updateKeys)
+  appendUpdateParams(nextSearchParams, updates)
+
+  if (currentSearchParams.toString() === nextSearchParams.toString()) return null
+
+  const url = new URL(path, "http://placeholder")
+  const search = nextSearchParams.toString()
+
+  return `${url.pathname}${search ? `?${search}` : ""}${url.hash}`
+}
+
+/**
+ * Builds search params for the current route params.
+ * @param {QueryParams} params Params to serialize.
+ * @param {Set<string>} excludedKeys Param keys to skip.
+ * @returns {URLSearchParams} Serialized search params.
+ */
+function searchParamsFor(params, excludedKeys) {
+  const searchParams = new URLSearchParams()
+
+  appendCurrentParams(searchParams, params, excludedKeys, new Set())
+
+  return searchParams
+}
+
+/**
+ * Appends current params that should survive the update.
+ * @param {URLSearchParams} searchParams Search params being built.
+ * @param {QueryParams} params Current route params.
+ * @param {Set<string>} excludedKeys Param keys to skip.
+ * @param {Set<string>} updateKeys Param keys replaced by the update.
+ * @returns {void} Nothing.
+ */
+function appendCurrentParams(searchParams, params, excludedKeys, updateKeys) {
+  for (const key of Object.keys(params).sort()) {
+    if (excludedKeys.has(key) || updateKeys.has(key)) continue
+    appendQueryParam(searchParams, key, params[key])
+  }
+}
+
+/**
+ * Appends updated params.
+ * @param {URLSearchParams} searchParams Search params being built.
+ * @param {QueryParamUpdates} updates Param updates to append.
+ * @returns {void} Nothing.
+ */
+function appendUpdateParams(searchParams, updates) {
+  for (const key of Object.keys(updates).sort()) {
+    appendQueryParam(searchParams, key, updates[key])
+  }
+}
+
+/**
+ * Appends a scalar or array query param.
+ * @param {URLSearchParams} searchParams Search params being built.
+ * @param {string} key Query key to append.
+ * @param {QueryParamValue | string | string[]} value Scalar or repeated query values.
+ * @returns {void} Nothing.
+ */
+function appendQueryParam(searchParams, key, value) {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      appendQueryParam(searchParams, key, item)
+    }
+    return
+  }
+  if (value === undefined || value === null || value === "") return
+  searchParams.append(key, String(value))
+}

--- a/src/query-param-updates.js
+++ b/src/query-param-updates.js
@@ -67,7 +67,7 @@ export function pathForQueryParamUpdates(
   const nextSearchParams = new URLSearchParams()
 
   appendCurrentParams(nextSearchParams, currentParams, excludedKeys, updateKeys)
-  appendUpdateParams(nextSearchParams, updates)
+  appendUpdateParams(nextSearchParams, updates, excludedKeys)
 
   if (currentSearchParams.toString() === nextSearchParams.toString()) return null
 
@@ -110,10 +110,12 @@ function appendCurrentParams(searchParams, params, excludedKeys, updateKeys) {
  * Appends updated params.
  * @param {URLSearchParams} searchParams Search params being built.
  * @param {QueryParamUpdates} updates Param updates to append.
+ * @param {Set<string>} excludedKeys Param keys to skip.
  * @returns {void} Nothing.
  */
-function appendUpdateParams(searchParams, updates) {
+function appendUpdateParams(searchParams, updates, excludedKeys) {
   for (const key of Object.keys(updates).sort()) {
+    if (excludedKeys.has(key)) continue
     appendQueryParam(searchParams, key, updates[key])
   }
 }

--- a/src/use-current-query-params.js
+++ b/src/use-current-query-params.js
@@ -1,0 +1,16 @@
+// @ts-check
+
+import {useCallback, useContext} from "react"
+import {LocationStoreContext} from "./location-context.js"
+
+/**
+ * Returns a stable reader for the provider-scoped current query params.
+ * @returns {() => Record<string, unknown>} Function that reads current query params without subscribing broadly.
+ */
+const useCurrentQueryParams = () => {
+  const locationStore = useContext(LocationStoreContext)
+
+  return useCallback(() => locationStore.queryParams(), [locationStore])
+}
+
+export default useCurrentQueryParams

--- a/src/with-custom-path.jsx
+++ b/src/with-custom-path.jsx
@@ -1,5 +1,6 @@
-import React, {memo, useEffect, useRef} from "react"
-import {LocationContext, LocationStoreContext, QueryParamsContext, defaultLocationStore} from "./location-context"
+import React, {memo, useEffect, useMemo, useRef} from "react"
+import {LocationContext, LocationStoreContext, QueryParamsContext} from "./location-context"
+import {LocationStore} from "./location-store.js"
 import {queryParamsKey} from "./query-param-selector.js"
 
 const withCustomPath = memo(({children, path, queryParams, ...restProps}) => {
@@ -13,8 +14,9 @@ const withCustomPath = memo(({children, path, queryParams, ...restProps}) => {
   const typedQueryParams = queryParams || {}
   const publishedSnapshotKeyRef = useRef("")
   const snapshotKey = `${typedPath}\n${queryParamsKey(typedQueryParams)}`
+  const locationStore = useMemo(() => new LocationStore(), [])
 
-  defaultLocationStore.replaceSnapshotSilently({
+  locationStore.replaceSnapshotSilently({
     path: typedPath,
     queryParams: typedQueryParams
   })
@@ -25,13 +27,13 @@ const withCustomPath = memo(({children, path, queryParams, ...restProps}) => {
     publishedSnapshotKeyRef.current = snapshotKey
     queueMicrotask(() => {
       if (publishedSnapshotKeyRef.current === snapshotKey) {
-        defaultLocationStore.flushPendingNotification()
+        locationStore.flushPendingNotification()
       }
     })
-  }, [snapshotKey])
+  }, [locationStore, snapshotKey])
 
   return (
-    <LocationStoreContext.Provider value={defaultLocationStore}>
+    <LocationStoreContext.Provider value={locationStore}>
       <LocationContext.Provider value={typedPath}>
         <QueryParamsContext.Provider value={typedQueryParams}>
           {children}

--- a/src/with-custom-path.jsx
+++ b/src/with-custom-path.jsx
@@ -1,6 +1,6 @@
-import React, {memo, useLayoutEffect, useMemo} from "react"
-import {LocationContext, LocationStoreContext, QueryParamsContext} from "./location-context"
-import {LocationStore} from "./location-store.js"
+import React, {memo, useEffect, useRef} from "react"
+import {LocationContext, LocationStoreContext, QueryParamsContext, defaultLocationStore} from "./location-context"
+import {queryParamsKey} from "./query-param-selector.js"
 
 const withCustomPath = memo(({children, path, queryParams, ...restProps}) => {
   const restPropsKeys = Object.keys(restProps)
@@ -9,15 +9,31 @@ const withCustomPath = memo(({children, path, queryParams, ...restProps}) => {
     throw new Error(`Unhandled props given: ${restPropsKeys.join(", ")}`)
   }
 
-  const locationStore = useMemo(() => new LocationStore(), [])
+  const typedPath = path || "/"
+  const typedQueryParams = queryParams || {}
+  const publishedSnapshotKeyRef = useRef("")
+  const snapshotKey = `${typedPath}\n${queryParamsKey(typedQueryParams)}`
 
-  locationStore.replaceSnapshotSilently({path, queryParams})
-  useLayoutEffect(locationStore.flushPendingNotification, [locationStore, path, queryParams])
+  defaultLocationStore.replaceSnapshotSilently({
+    path: typedPath,
+    queryParams: typedQueryParams
+  })
+
+  useEffect(() => {
+    if (publishedSnapshotKeyRef.current === snapshotKey) return
+
+    publishedSnapshotKeyRef.current = snapshotKey
+    queueMicrotask(() => {
+      if (publishedSnapshotKeyRef.current === snapshotKey) {
+        defaultLocationStore.flushPendingNotification()
+      }
+    })
+  }, [snapshotKey])
 
   return (
-    <LocationStoreContext.Provider value={locationStore}>
-      <LocationContext.Provider value={path}>
-        <QueryParamsContext.Provider value={queryParams}>
+    <LocationStoreContext.Provider value={defaultLocationStore}>
+      <LocationContext.Provider value={typedPath}>
+        <QueryParamsContext.Provider value={typedQueryParams}>
           {children}
         </QueryParamsContext.Provider>
       </LocationContext.Provider>


### PR DESCRIPTION
## Summary
- publish provider-scoped current-query-param helpers from on-location-changed
- add reusable query-param path/update helpers for Expo Router filters
- have WithCustomPath publish snapshots through the shared store and defer notifications to avoid React commit-time rerenders

## Checks
- npm run lint (passes with existing warnings)
- npm run build
- npm pack --dry-run